### PR TITLE
feat: Add `emath::Number` compatibility and `Default` impl, add `new_masked` and `into_inner` functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "ux2"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "criterion",
  "emath",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "ux2-macros"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "emath"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee58355767587db7ba3738930d93cad3052cd834c2b48b9ef6ef26fe4823b7e"
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -572,6 +578,7 @@ name = "ux2"
 version = "0.8.5"
 dependencies = [
  "criterion",
+ "emath",
  "rand",
  "serde",
  "ux2-macros",

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.10.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.9.0...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
+## [Upcoming Release](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.9.0...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
 
 
 ### Features

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 ### Features
 
-* Add `emath::Number` compat ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
-* Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
-* Add `new_mask` and `into_inner` ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))
+* Add `new_mask` and `into_inner` and Default for signed types ([ae8e529c](https://github.com/JonathanWoollett-Light/ux2/commit/ae8e529c8dc02a0f18be338ca0e2c26fabeec8b4))
+* Add Default impl for unsigned types ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
+* Add `new_mask` and `into_inner` for unsigned types ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))
 
 ## [0.9.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.8.0...ux2-macros-v0.9.0) (2023-08-30)
 

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+* Pull as much from core as possible ([191d4f48](https://github.com/JonathanWoollett-Light/ux2/commit/191d4f480c73addc3966be1631955c4a0362647f))
 * Add `new_mask` and `into_inner` and Default for signed types ([ae8e529c](https://github.com/JonathanWoollett-Light/ux2/commit/ae8e529c8dc02a0f18be338ca0e2c26fabeec8b4))
 * Add Default impl for unsigned types ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
 * Add `new_mask` and `into_inner` for unsigned types ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 * Add `emath::Number` compat ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
+* Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
 
 ## [0.9.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.8.0...ux2-macros-v0.9.0) (2023-08-30)
 

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.10.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.9.0...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
+
+
+### Features
+
+* Add `emath::Number` compat ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
+
 ## [0.9.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.8.0...ux2-macros-v0.9.0) (2023-08-30)
 
 

--- a/ux2-macros/CHANGELOG.md
+++ b/ux2-macros/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Add `emath::Number` compat ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
 * Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
+* Add `new_mask` and `into_inner` ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))
 
 ## [0.9.0](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-macros-v0.8.0...ux2-macros-v0.9.0) (2023-08-30)
 

--- a/ux2-macros/Cargo.toml
+++ b/ux2-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ux2-macros"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Macro backend for ux2"
 license = "Apache-2.0"

--- a/ux2-macros/src/lib.rs
+++ b/ux2-macros/src/lib.rs
@@ -823,6 +823,22 @@ pub fn generate_types(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
             #[repr(transparent)]
             #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash)]
             pub struct #unsigned_ident(#unsigned_inner_ident);
+            #[cfg(feature = "emath")]
+            impl emath::Numeric for #unsigned_ident {
+                const INTEGRAL: bool = false;
+                const MIN: Self = #unsigned_ident::MIN;
+                const MAX: Self = #unsigned_ident::MAX;
+
+                #[inline(always)]
+                fn to_f64(self) -> f64 {
+                    self.0 as f64
+                }
+
+                #[inline(always)]
+                fn from_f64(num: f64) -> Self {
+                    Self::new(num as #unsigned_inner_ident)
+                }
+            }
             impl #unsigned_ident {
                 fn mask(self) -> Self {
                     Self(self.0 & #unsigned_mask.overflowing_sub(#unsigned_one).0)

--- a/ux2-macros/src/lib.rs
+++ b/ux2-macros/src/lib.rs
@@ -839,6 +839,11 @@ pub fn generate_types(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
                     Self::new(num as #unsigned_inner_ident)
                 }
             }
+            impl core::default::Default for #unsigned_ident {
+                fn default() -> Self {
+                    #unsigned_ident::new(#unsigned_inner_ident::default())
+                }
+            }
             impl #unsigned_ident {
                 fn mask(self) -> Self {
                     Self(self.0 & #unsigned_mask.overflowing_sub(#unsigned_one).0)

--- a/ux2-macros/src/lib.rs
+++ b/ux2-macros/src/lib.rs
@@ -823,8 +823,8 @@ pub fn generate_types(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
             #[repr(transparent)]
             #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Clone, Copy, Hash)]
             pub struct #unsigned_ident(#unsigned_inner_ident);
-            #[cfg(feature = "emath")]
-            impl emath::Numeric for #unsigned_ident {
+            #[cfg(feature = "emath_0_25")]
+            impl emath_0_25::Numeric for #unsigned_ident {
                 const INTEGRAL: bool = false;
                 const MIN: Self = #unsigned_ident::MIN;
                 const MAX: Self = #unsigned_ident::MAX;

--- a/ux2-macros/src/lib.rs
+++ b/ux2-macros/src/lib.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use core::str::FromStr;
 
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
@@ -22,7 +22,7 @@ pub fn generate_types(item: proc_macro::TokenStream) -> proc_macro::TokenStream 
     assert!(items.next().is_none());
 
     let output = (1..=max).map(|size| {
-        let inner_size = std::cmp::max(size.next_power_of_two(),8);
+        let inner_size = core::cmp::max(size.next_power_of_two(),8);
         let inner_bytes = (inner_size / 8) as usize;
         let bits = size as u32;
         let bytes = match size % 8 {
@@ -76,13 +76,13 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
 ");
         let unsigned_wrapping_add_examples = format!(" assert_eq!({unsigned_ident}::MAX.wrapping_add({unsigned_ident}::try_from({unsigned_one}).unwrap()), {unsigned_ident}::MIN);");
 
-        let unsigned_add_ops = (1..max).filter(|rhs| std::cmp::max(rhs,&size) < &max).map(|s| {
+        let unsigned_add_ops = (1..max).filter(|rhs| core::cmp::max(rhs,&size) < &max).map(|s| {
             let rhs_ident = format_ident!("u{s}");
-            let out_size = std::cmp::max(size,s) + 1;
+            let out_size = core::cmp::max(size,s) + 1;
             let out_ident = format_ident!("u{out_size}");
 
             quote! {
-                impl std::ops::Add<&#rhs_ident> for &#unsigned_ident {
+                impl core::ops::Add<&#rhs_ident> for &#unsigned_ident {
                     type Output = #out_ident;
                     fn add(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -91,7 +91,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl std::ops::Add<&#rhs_ident> for #unsigned_ident {
+                impl core::ops::Add<&#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn add(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -100,7 +100,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl<'a> std::ops::Add<#rhs_ident> for &'a #unsigned_ident {
+                impl<'a> core::ops::Add<#rhs_ident> for &'a #unsigned_ident {
                     type Output = #out_ident;
                     fn add(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -109,7 +109,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl std::ops::Add<#rhs_ident> for #unsigned_ident {
+                impl core::ops::Add<#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn add(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -127,7 +127,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
             let out_ident = format_ident!("u{out_size}");
 
             quote! {
-                impl std::ops::Mul<&#rhs_ident> for &#unsigned_ident {
+                impl core::ops::Mul<&#rhs_ident> for &#unsigned_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -136,7 +136,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(z)
                     }
                 }
-                impl std::ops::Mul<&#rhs_ident> for #unsigned_ident {
+                impl core::ops::Mul<&#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -145,7 +145,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(z)
                     }
                 }
-                impl<'a> std::ops::Mul<#rhs_ident> for &'a #unsigned_ident {
+                impl<'a> core::ops::Mul<#rhs_ident> for &'a #unsigned_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -154,7 +154,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(z)
                     }
                 }
-                impl std::ops::Mul<#rhs_ident> for #unsigned_ident {
+                impl core::ops::Mul<#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -166,13 +166,13 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
             }
         }).collect::<TokenStream>();
 
-        let unsigned_sub_ops = (1..max).filter(|rhs| std::cmp::max(rhs,&size) < &max).map(|s| {
+        let unsigned_sub_ops = (1..max).filter(|rhs| core::cmp::max(rhs,&size) < &max).map(|s| {
             let rhs_ident = format_ident!("u{s}");
-            let out_size = std::cmp::max(size,s)+1;
+            let out_size = core::cmp::max(size,s)+1;
             let out_ident = format_ident!("i{out_size}");
 
             quote! {
-                impl std::ops::Sub<&#rhs_ident> for &#unsigned_ident {
+                impl core::ops::Sub<&#rhs_ident> for &#unsigned_ident {
                     type Output = #out_ident;
                     fn sub(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -181,7 +181,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl std::ops::Sub<&#rhs_ident> for #unsigned_ident {
+                impl core::ops::Sub<&#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn sub(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -190,7 +190,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl<'a> std::ops::Sub<#rhs_ident> for &'a #unsigned_ident {
+                impl<'a> core::ops::Sub<#rhs_ident> for &'a #unsigned_ident {
                     type Output = #out_ident;
                     fn sub(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -199,7 +199,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident(x)
                     }
                 }
-                impl std::ops::Sub<#rhs_ident> for #unsigned_ident {
+                impl core::ops::Sub<#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn sub(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -213,12 +213,12 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
 
         let unsigned_rem_ops = (1..max).filter(|rhs|rhs < &max).map(|s|{
             let rhs_ident = format_ident!("u{s}");
-            let out_size = std::cmp::min(size,s);
+            let out_size = core::cmp::min(size,s);
             let out_ident = format_ident!("u{out_size}");
-            let max_ident = std::cmp::max(size,s);
+            let max_ident = core::cmp::max(size,s);
             let max_ident = format_ident!("u{max_ident}");
             quote! {
-                impl std::ops::Rem<&#rhs_ident> for &#unsigned_ident {
+                impl core::ops::Rem<&#rhs_ident> for &#unsigned_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: &#rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(*self).0;
@@ -226,7 +226,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl std::ops::Rem<&#rhs_ident> for #unsigned_ident {
+                impl core::ops::Rem<&#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: &#rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(self).0;
@@ -234,7 +234,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl<'a> std::ops::Rem<#rhs_ident> for &'a #unsigned_ident {
+                impl<'a> core::ops::Rem<#rhs_ident> for &'a #unsigned_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: #rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(*self).0;
@@ -242,7 +242,7 @@ assert_eq!({unsigned_ident}::new_mask({unsigned_inner_ident}::default()), {unsig
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl std::ops::Rem<#rhs_ident> for #unsigned_ident {
+                impl core::ops::Rem<#rhs_ident> for #unsigned_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: #rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(self).0;
@@ -309,13 +309,13 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::MIN), {signed_ident}::
 assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_ident}::default());
 ");
 
-        let signed_add_ops = (1..max).filter(|rhs| std::cmp::max(rhs,&size) < &max).map(|s| {
+        let signed_add_ops = (1..max).filter(|rhs| core::cmp::max(rhs,&size) < &max).map(|s| {
             let signed_rhs = format_ident!("i{s}");
-            let output_size = std::cmp::max(size,s) + 1;
+            let output_size = core::cmp::max(size,s) + 1;
             let signed_ident_plus_one = format_ident!("i{output_size}");
 
             quote! {
-                impl std::ops::Add<&#signed_rhs> for &#signed_ident {
+                impl core::ops::Add<&#signed_rhs> for &#signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn add(self, rhs: &#signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(*self).0;
@@ -324,7 +324,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl std::ops::Add<&#signed_rhs> for #signed_ident {
+                impl core::ops::Add<&#signed_rhs> for #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn add(self, rhs: &#signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(self).0;
@@ -333,7 +333,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl<'a> std::ops::Add<#signed_rhs> for &'a #signed_ident {
+                impl<'a> core::ops::Add<#signed_rhs> for &'a #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn add(self, rhs: #signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(*self).0;
@@ -342,7 +342,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl std::ops::Add<#signed_rhs> for #signed_ident {
+                impl core::ops::Add<#signed_rhs> for #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn add(self, rhs: #signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(self).0;
@@ -360,7 +360,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
             let out_ident = format_ident!("i{out}");
 
             quote! {
-                impl std::ops::Mul<&#rhs_ident> for &#signed_ident {
+                impl core::ops::Mul<&#rhs_ident> for &#signed_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -369,7 +369,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident(z)
                     }
                 }
-                impl std::ops::Mul<&#rhs_ident> for #signed_ident {
+                impl core::ops::Mul<&#rhs_ident> for #signed_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: &#rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -378,7 +378,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident(z)
                     }
                 }
-                impl<'a> std::ops::Mul<#rhs_ident> for &'a #signed_ident {
+                impl<'a> core::ops::Mul<#rhs_ident> for &'a #signed_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(*self).0;
@@ -387,7 +387,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident(z)
                     }
                 }
-                impl std::ops::Mul<#rhs_ident> for #signed_ident {
+                impl core::ops::Mul<#rhs_ident> for #signed_ident {
                     type Output = #out_ident;
                     fn mul(self, rhs: #rhs_ident) -> Self::Output {
                         let mut x = <#out_ident>::from(self).0;
@@ -399,13 +399,13 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
             }
         }).collect::<TokenStream>();
 
-        let signed_sub_ops = (1..max).filter(|rhs| std::cmp::max(rhs,&size) < &max).map(|s| {
+        let signed_sub_ops = (1..max).filter(|rhs| core::cmp::max(rhs,&size) < &max).map(|s| {
             let signed_rhs = format_ident!("i{s}");
-            let output_size = std::cmp::max(size,s) + 1;
+            let output_size = core::cmp::max(size,s) + 1;
             let signed_ident_plus_one = format_ident!("i{output_size}");
 
             quote! {
-                impl std::ops::Sub<&#signed_rhs> for &#signed_ident {
+                impl core::ops::Sub<&#signed_rhs> for &#signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn sub(self, rhs: &#signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(*self).0;
@@ -414,7 +414,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl std::ops::Sub<&#signed_rhs> for #signed_ident {
+                impl core::ops::Sub<&#signed_rhs> for #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn sub(self, rhs: &#signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(self).0;
@@ -423,7 +423,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl<'a> std::ops::Sub<#signed_rhs> for &'a #signed_ident {
+                impl<'a> core::ops::Sub<#signed_rhs> for &'a #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn sub(self, rhs: #signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(*self).0;
@@ -432,7 +432,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #signed_ident_plus_one(x)
                     }
                 }
-                impl std::ops::Sub<#signed_rhs> for #signed_ident {
+                impl core::ops::Sub<#signed_rhs> for #signed_ident {
                     type Output = #signed_ident_plus_one;
                     fn sub(self, rhs: #signed_rhs) -> Self::Output {
                         let mut x = <#signed_ident_plus_one>::from(self).0;
@@ -446,12 +446,12 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
 
         let signed_rem_ops = (1..max).filter(|rhs|rhs < &max).map(|s|{
             let rhs_ident = format_ident!("i{s}");
-            let out_size = std::cmp::min(size,s);
+            let out_size = core::cmp::min(size,s);
             let out_ident = format_ident!("i{out_size}");
-            let max_ident = std::cmp::max(size,s);
+            let max_ident = core::cmp::max(size,s);
             let max_ident = format_ident!("i{max_ident}");
             quote! {
-                impl std::ops::Rem<&#rhs_ident> for &#signed_ident {
+                impl core::ops::Rem<&#rhs_ident> for &#signed_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: &#rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(*self).0;
@@ -459,7 +459,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl std::ops::Rem<&#rhs_ident> for #signed_ident {
+                impl core::ops::Rem<&#rhs_ident> for #signed_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: &#rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(self).0;
@@ -467,7 +467,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl<'a> std::ops::Rem<#rhs_ident> for &'a #signed_ident {
+                impl<'a> core::ops::Rem<#rhs_ident> for &'a #signed_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: #rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(*self).0;
@@ -475,7 +475,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         #out_ident::try_from(x % y).unwrap()
                     }
                 }
-                impl std::ops::Rem<#rhs_ident> for #signed_ident {
+                impl core::ops::Rem<#rhs_ident> for #signed_ident {
                     type Output = #out_ident;
                     fn rem(self, rhs: #rhs_ident) -> Self::Output {
                         let x = <#max_ident>::from(self).0;
@@ -487,8 +487,8 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
         }).collect::<TokenStream>();
 
         let unsigned_from_implementations = {
-            let pointer_width_from = std::iter::once(match size.cmp(&TARGET_POINTER_WIDTH) {
-                std::cmp::Ordering::Greater => quote! {
+            let pointer_width_from = core::iter::once(match size.cmp(&TARGET_POINTER_WIDTH) {
+                core::cmp::Ordering::Greater => quote! {
                     impl From<usize> for #unsigned_ident {
                         fn from(x: usize) -> Self {
                             Self(x as #unsigned_inner_ident)
@@ -501,7 +501,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         }
                     }
                 },
-                std::cmp::Ordering::Equal => quote! {
+                core::cmp::Ordering::Equal => quote! {
                     impl From<usize> for #unsigned_ident {
                         fn from(x: usize) -> Self {
                             Self(x as #unsigned_inner_ident)
@@ -513,7 +513,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         }
                     }
                 },
-                std::cmp::Ordering::Less => quote! {
+                core::cmp::Ordering::Less => quote! {
                     impl TryFrom<usize> for #unsigned_ident {
                         type Error = TryFromIntError;
                         fn try_from(x: usize) -> Result<Self, Self::Error> {
@@ -538,7 +538,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 let from_ident = format_ident!("u{s}");
                 let from_ident = quote! { core::primitive::#from_ident };
                 match size.cmp(&s) {
-                    std::cmp::Ordering::Equal => quote!{
+                    core::cmp::Ordering::Equal => quote!{
                         impl From<#from_ident> for #unsigned_ident {
                             fn from(x: #from_ident) -> Self {
                                 Self(<#unsigned_inner_ident>::from(x))
@@ -550,7 +550,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                             }
                         }
                     },
-                    std::cmp::Ordering::Greater => quote! {
+                    core::cmp::Ordering::Greater => quote! {
                         impl From<#from_ident> for #unsigned_ident {
                             fn from(x: #from_ident) -> Self {
                                 Self(<#unsigned_inner_ident>::from(x))
@@ -563,7 +563,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                             }
                         }
                     },
-                    std::cmp::Ordering::Less => quote! {
+                    core::cmp::Ordering::Less => quote! {
                         impl TryFrom<#from_ident> for #unsigned_ident {
                             type Error = TryFromIntError;
                             fn try_from(x: #from_ident) -> Result<Self, Self::Error> {
@@ -602,7 +602,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     }
                 }
             });
-            let same = std::iter::once({
+            let same = core::iter::once({
                 quote! {
                     impl TryFrom<#signed_ident> for #unsigned_ident {
                         type Error = TryFromIntError;
@@ -645,8 +645,8 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
             pointer_width_from.chain(primitive_from).chain(smaller).chain(same).chain(bigger).collect::<TokenStream>()
         };
         let signed_from_implementations = {
-            let pointer_width_from = std::iter::once(match size.cmp(&TARGET_POINTER_WIDTH) {
-                std::cmp::Ordering::Greater => quote! {
+            let pointer_width_from = core::iter::once(match size.cmp(&TARGET_POINTER_WIDTH) {
+                core::cmp::Ordering::Greater => quote! {
                     impl From<isize> for #signed_ident {
                         fn from(x: isize) -> Self {
                             Self(x as #signed_inner_ident)
@@ -659,7 +659,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         }
                     }
                 },
-                std::cmp::Ordering::Equal => quote! {
+                core::cmp::Ordering::Equal => quote! {
                     impl From<isize> for #signed_ident {
                         fn from(x: isize) -> Self {
                             Self(x as #signed_inner_ident)
@@ -671,7 +671,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                         }
                     }
                 },
-                std::cmp::Ordering::Less => quote! {
+                core::cmp::Ordering::Less => quote! {
                     impl TryFrom<isize> for #signed_ident {
                         type Error = TryFromIntError;
                         fn try_from(x: isize) -> Result<Self,Self::Error> {
@@ -696,7 +696,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 let from_ident = format_ident!("i{s}");
                 let from_ident = quote! { core::primitive::#from_ident };
                 match size.cmp(&s) {
-                    std::cmp::Ordering::Equal => quote!{
+                    core::cmp::Ordering::Equal => quote!{
                         impl From<#from_ident> for #signed_ident {
                             fn from(x: #from_ident) -> Self {
                                 Self(<#signed_inner_ident>::from(x))
@@ -708,7 +708,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                             }
                         }
                     },
-                    std::cmp::Ordering::Greater => quote! {
+                    core::cmp::Ordering::Greater => quote! {
                         impl From<#from_ident> for #signed_ident {
                             fn from(x: #from_ident) -> Self {
                                 Self(<#signed_inner_ident>::from(x))
@@ -721,7 +721,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                             }
                         }
                     },
-                    std::cmp::Ordering::Less => quote! {
+                    core::cmp::Ordering::Less => quote! {
                         impl TryFrom<#from_ident> for #signed_ident {
                             type Error = TryFromIntError;
                             fn try_from(x: #from_ident) -> Result<Self, Self::Error> {
@@ -760,7 +760,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             });
 
-            let same = std::iter::once({
+            let same = core::iter::once({
                 quote! {
                     impl TryFrom<#unsigned_ident> for #signed_ident {
                         type Error = TryFromIntError;
@@ -814,7 +814,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
 
         let signed_abs = if let Some(minus @ 1..) = size.checked_sub(1) {
             let ident = format_ident!("u{minus}");
-            let inner_size = std::cmp::max(minus.next_power_of_two(),8);
+            let inner_size = core::cmp::max(minus.next_power_of_two(),8);
             let inner_ident = format_ident!("u{inner_size}");
             let inner_ident = quote! { core::primitive::#inner_ident };
             quote! {
@@ -1057,7 +1057,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
             #unsigned_sub_ops
             #unsigned_rem_ops
 
-            impl std::ops::Div<&#unsigned_ident> for &#unsigned_ident {
+            impl core::ops::Div<&#unsigned_ident> for &#unsigned_ident {
                 type Output = #unsigned_ident;
                 fn div(self, rhs: &#unsigned_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1065,7 +1065,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #unsigned_ident(x)
                 }
             }
-            impl std::ops::Div<&#unsigned_ident> for #unsigned_ident {
+            impl core::ops::Div<&#unsigned_ident> for #unsigned_ident {
                 type Output = #unsigned_ident;
                 fn div(self, rhs: &#unsigned_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1073,7 +1073,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #unsigned_ident(x)
                 }
             }
-            impl<'a> std::ops::Div<#unsigned_ident> for &'a #unsigned_ident {
+            impl<'a> core::ops::Div<#unsigned_ident> for &'a #unsigned_ident {
                 type Output = #unsigned_ident;
                 fn div(self, rhs: #unsigned_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1081,7 +1081,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #unsigned_ident(x)
                 }
             }
-            impl std::ops::Div<#unsigned_ident> for #unsigned_ident {
+            impl core::ops::Div<#unsigned_ident> for #unsigned_ident {
                 type Output = #unsigned_ident;
                 fn div(self, rhs: #unsigned_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1090,54 +1090,54 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::fmt::Display for #unsigned_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl core::fmt::Display for #unsigned_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     write!(f,"{}",self.0)
                 }
             }
-            impl std::fmt::Binary for #unsigned_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Binary::fmt(&self.0, f)
+            impl core::fmt::Binary for #unsigned_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Binary::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::LowerHex for #unsigned_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::LowerHex::fmt(&self.0, f)
+            impl core::fmt::LowerHex for #unsigned_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::LowerHex::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::UpperHex for #unsigned_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::UpperHex::fmt(&self.0, f)
+            impl core::fmt::UpperHex for #unsigned_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::UpperHex::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::Octal for #unsigned_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Octal::fmt(&self.0, f)
+            impl core::fmt::Octal for #unsigned_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Octal::fmt(&self.0, f)
                 }
             }
 
-            impl std::ops::BitAnd<&#unsigned_ident> for &#unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitAnd<#unsigned_ident>>::Output;
-
-                fn bitand(self, rhs: &#unsigned_ident) -> Self::Output {
-                    #unsigned_ident(self.0 & rhs.0)
-                }
-            }
-            impl std::ops::BitAnd<&#unsigned_ident> for #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitAnd<#unsigned_ident>>::Output;
+            impl core::ops::BitAnd<&#unsigned_ident> for &#unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitAnd<#unsigned_ident>>::Output;
 
                 fn bitand(self, rhs: &#unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 & rhs.0)
                 }
             }
-            impl<'a> std::ops::BitAnd<#unsigned_ident> for &'a #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitAnd<#unsigned_ident>>::Output;
+            impl core::ops::BitAnd<&#unsigned_ident> for #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitAnd<#unsigned_ident>>::Output;
+
+                fn bitand(self, rhs: &#unsigned_ident) -> Self::Output {
+                    #unsigned_ident(self.0 & rhs.0)
+                }
+            }
+            impl<'a> core::ops::BitAnd<#unsigned_ident> for &'a #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitAnd<#unsigned_ident>>::Output;
 
                 fn bitand(self, rhs: #unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 & rhs.0)
                 }
             }
-            impl std::ops::BitAnd<#unsigned_ident> for #unsigned_ident {
+            impl core::ops::BitAnd<#unsigned_ident> for #unsigned_ident {
                 type Output = Self;
 
                 fn bitand(self, rhs: Self) -> Self::Output {
@@ -1145,28 +1145,28 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::BitOr<&#unsigned_ident> for &#unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitOr<#unsigned_ident>>::Output;
+            impl core::ops::BitOr<&#unsigned_ident> for &#unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitOr<#unsigned_ident>>::Output;
 
                 fn bitor(self, rhs: &#unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 | rhs.0)
                 }
             }
-            impl std::ops::BitOr<&#unsigned_ident> for #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitOr<#unsigned_ident>>::Output;
+            impl core::ops::BitOr<&#unsigned_ident> for #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitOr<#unsigned_ident>>::Output;
 
                 fn bitor(self, rhs: &#unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 | rhs.0)
                 }
             }
-            impl<'a> std::ops::BitOr<#unsigned_ident> for &'a #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitOr<#unsigned_ident>>::Output;
+            impl<'a> core::ops::BitOr<#unsigned_ident> for &'a #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitOr<#unsigned_ident>>::Output;
 
                 fn bitor(self, rhs: #unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 | rhs.0)
                 }
             }
-            impl std::ops::BitOr<#unsigned_ident> for #unsigned_ident {
+            impl core::ops::BitOr<#unsigned_ident> for #unsigned_ident {
                 type Output = Self;
 
                 fn bitor(self, rhs: Self) -> Self::Output {
@@ -1174,28 +1174,28 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::BitXor<&#unsigned_ident> for &#unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitXor<#unsigned_ident>>::Output;
+            impl core::ops::BitXor<&#unsigned_ident> for &#unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitXor<#unsigned_ident>>::Output;
 
                 fn bitxor(self, rhs: &#unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 ^ rhs.0)
                 }
             }
-            impl std::ops::BitXor<&#unsigned_ident> for #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitXor<#unsigned_ident>>::Output;
+            impl core::ops::BitXor<&#unsigned_ident> for #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitXor<#unsigned_ident>>::Output;
 
                 fn bitxor(self, rhs: &#unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 ^ rhs.0)
                 }
             }
-            impl<'a> std::ops::BitXor<#unsigned_ident> for &'a #unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::BitXor<#unsigned_ident>>::Output;
+            impl<'a> core::ops::BitXor<#unsigned_ident> for &'a #unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::BitXor<#unsigned_ident>>::Output;
 
                 fn bitxor(self, rhs: #unsigned_ident) -> Self::Output {
                     #unsigned_ident(self.0 ^ rhs.0)
                 }
             }
-            impl std::ops::BitXor<#unsigned_ident> for #unsigned_ident {
+            impl core::ops::BitXor<#unsigned_ident> for #unsigned_ident {
                 type Output = Self;
 
                 fn bitxor(self, rhs: Self) -> Self::Output {
@@ -1203,15 +1203,15 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::Not for #unsigned_ident {
+            impl core::ops::Not for #unsigned_ident {
                 type Output = Self;
 
                 fn not(self) -> Self::Output {
                     #unsigned_ident(self.0)
                 }
             }
-            impl std::ops::Not for &#unsigned_ident {
-                type Output = <#unsigned_ident as std::ops::Not>::Output;
+            impl core::ops::Not for &#unsigned_ident {
+                type Output = <#unsigned_ident as core::ops::Not>::Output;
 
                 fn not(self) -> Self::Output {
                     #unsigned_ident(self.0)
@@ -1466,7 +1466,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
             #signed_sub_ops
             #signed_rem_ops
 
-            impl std::ops::Div<&#signed_ident> for &#signed_ident {
+            impl core::ops::Div<&#signed_ident> for &#signed_ident {
                 type Output = #signed_ident;
                 fn div(self, rhs: &#signed_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1474,7 +1474,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #signed_ident(x)
                 }
             }
-            impl std::ops::Div<&#signed_ident> for #signed_ident {
+            impl core::ops::Div<&#signed_ident> for #signed_ident {
                 type Output = #signed_ident;
                 fn div(self, rhs: &#signed_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1482,7 +1482,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #signed_ident(x)
                 }
             }
-            impl<'a> std::ops::Div<#signed_ident> for &'a #signed_ident {
+            impl<'a> core::ops::Div<#signed_ident> for &'a #signed_ident {
                 type Output = #signed_ident;
                 fn div(self, rhs: #signed_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1490,7 +1490,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                     #signed_ident(x)
                 }
             }
-            impl std::ops::Div<#signed_ident> for #signed_ident {
+            impl core::ops::Div<#signed_ident> for #signed_ident {
                 type Output = #signed_ident;
                 fn div(self, rhs: #signed_ident) -> Self::Output {
                     let x = self.0 / rhs.0;
@@ -1499,54 +1499,54 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::fmt::Display for #signed_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            impl core::fmt::Display for #signed_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     write!(f,"{}",self.0)
                 }
             }
-            impl std::fmt::Binary for #signed_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Binary::fmt(&self.0, f)
+            impl core::fmt::Binary for #signed_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Binary::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::LowerHex for #signed_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::LowerHex::fmt(&self.0, f)
+            impl core::fmt::LowerHex for #signed_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::LowerHex::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::UpperHex for #signed_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::UpperHex::fmt(&self.0, f)
+            impl core::fmt::UpperHex for #signed_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::UpperHex::fmt(&self.0, f)
                 }
             }
-            impl std::fmt::Octal for #signed_ident {
-                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    std::fmt::Octal::fmt(&self.0, f)
+            impl core::fmt::Octal for #signed_ident {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    core::fmt::Octal::fmt(&self.0, f)
                 }
             }
 
-            impl std::ops::BitAnd<&#signed_ident> for &#signed_ident {
-                type Output = <#signed_ident as std::ops::BitAnd<#signed_ident>>::Output;
-
-                fn bitand(self, rhs: &#signed_ident) -> Self::Output {
-                    #signed_ident(self.0 & rhs.0)
-                }
-            }
-            impl std::ops::BitAnd<&#signed_ident> for #signed_ident {
-                type Output = <#signed_ident as std::ops::BitAnd<#signed_ident>>::Output;
+            impl core::ops::BitAnd<&#signed_ident> for &#signed_ident {
+                type Output = <#signed_ident as core::ops::BitAnd<#signed_ident>>::Output;
 
                 fn bitand(self, rhs: &#signed_ident) -> Self::Output {
                     #signed_ident(self.0 & rhs.0)
                 }
             }
-            impl<'a> std::ops::BitAnd<#signed_ident> for &'a #signed_ident {
-                type Output = <#signed_ident as std::ops::BitAnd<#signed_ident>>::Output;
+            impl core::ops::BitAnd<&#signed_ident> for #signed_ident {
+                type Output = <#signed_ident as core::ops::BitAnd<#signed_ident>>::Output;
+
+                fn bitand(self, rhs: &#signed_ident) -> Self::Output {
+                    #signed_ident(self.0 & rhs.0)
+                }
+            }
+            impl<'a> core::ops::BitAnd<#signed_ident> for &'a #signed_ident {
+                type Output = <#signed_ident as core::ops::BitAnd<#signed_ident>>::Output;
 
                 fn bitand(self, rhs: #signed_ident) -> Self::Output {
                     #signed_ident(self.0 & rhs.0)
                 }
             }
-            impl std::ops::BitAnd<#signed_ident> for #signed_ident {
+            impl core::ops::BitAnd<#signed_ident> for #signed_ident {
                 type Output = Self;
 
                 fn bitand(self, rhs: Self) -> Self::Output {
@@ -1554,28 +1554,28 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::BitOr<&#signed_ident> for &#signed_ident {
-                type Output = <#signed_ident as std::ops::BitOr<#signed_ident>>::Output;
+            impl core::ops::BitOr<&#signed_ident> for &#signed_ident {
+                type Output = <#signed_ident as core::ops::BitOr<#signed_ident>>::Output;
 
                 fn bitor(self, rhs: &#signed_ident) -> Self::Output {
                     #signed_ident(self.0 | rhs.0)
                 }
             }
-            impl std::ops::BitOr<&#signed_ident> for #signed_ident {
-                type Output = <#signed_ident as std::ops::BitOr<#signed_ident>>::Output;
+            impl core::ops::BitOr<&#signed_ident> for #signed_ident {
+                type Output = <#signed_ident as core::ops::BitOr<#signed_ident>>::Output;
 
                 fn bitor(self, rhs: &#signed_ident) -> Self::Output {
                     #signed_ident(self.0 | rhs.0)
                 }
             }
-            impl<'a> std::ops::BitOr<#signed_ident> for &'a #signed_ident {
-                type Output = <#signed_ident as std::ops::BitOr<#signed_ident>>::Output;
+            impl<'a> core::ops::BitOr<#signed_ident> for &'a #signed_ident {
+                type Output = <#signed_ident as core::ops::BitOr<#signed_ident>>::Output;
 
                 fn bitor(self, rhs: #signed_ident) -> Self::Output {
                     #signed_ident(self.0 | rhs.0)
                 }
             }
-            impl std::ops::BitOr<#signed_ident> for #signed_ident {
+            impl core::ops::BitOr<#signed_ident> for #signed_ident {
                 type Output = Self;
 
                 fn bitor(self, rhs: Self) -> Self::Output {
@@ -1583,28 +1583,28 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::BitXor<&#signed_ident> for &#signed_ident {
-                type Output = <#signed_ident as std::ops::BitXor<#signed_ident>>::Output;
+            impl core::ops::BitXor<&#signed_ident> for &#signed_ident {
+                type Output = <#signed_ident as core::ops::BitXor<#signed_ident>>::Output;
 
                 fn bitxor(self, rhs: &#signed_ident) -> Self::Output {
                     #signed_ident(self.0 ^ rhs.0)
                 }
             }
-            impl std::ops::BitXor<&#signed_ident> for #signed_ident {
-                type Output = <#signed_ident as std::ops::BitXor<#signed_ident>>::Output;
+            impl core::ops::BitXor<&#signed_ident> for #signed_ident {
+                type Output = <#signed_ident as core::ops::BitXor<#signed_ident>>::Output;
 
                 fn bitxor(self, rhs: &#signed_ident) -> Self::Output {
                     #signed_ident(self.0 ^ rhs.0)
                 }
             }
-            impl<'a> std::ops::BitXor<#signed_ident> for &'a #signed_ident {
-                type Output = <#signed_ident as std::ops::BitXor<#signed_ident>>::Output;
+            impl<'a> core::ops::BitXor<#signed_ident> for &'a #signed_ident {
+                type Output = <#signed_ident as core::ops::BitXor<#signed_ident>>::Output;
 
                 fn bitxor(self, rhs: #signed_ident) -> Self::Output {
                     #signed_ident(self.0 ^ rhs.0)
                 }
             }
-            impl std::ops::BitXor<#signed_ident> for #signed_ident {
+            impl core::ops::BitXor<#signed_ident> for #signed_ident {
                 type Output = Self;
 
                 fn bitxor(self, rhs: Self) -> Self::Output {
@@ -1612,7 +1612,7 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::Neg for #signed_ident {
+            impl core::ops::Neg for #signed_ident {
                 type Output = Self;
                 fn neg(self) -> Self::Output {
                     assert_ne!(self,Self::MIN);
@@ -1620,15 +1620,15 @@ assert_eq!({signed_ident}::new_mask({signed_inner_ident}::default()), {signed_id
                 }
             }
 
-            impl std::ops::Not for #signed_ident {
+            impl core::ops::Not for #signed_ident {
                 type Output = Self;
 
                 fn not(self) -> Self::Output {
                     #signed_ident(self.0)
                 }
             }
-            impl std::ops::Not for &#signed_ident {
-                type Output = <#signed_ident as std::ops::Not>::Output;
+            impl core::ops::Not for &#signed_ident {
+                type Output = <#signed_ident as core::ops::Not>::Output;
 
                 fn not(self) -> Self::Output {
                     #signed_ident(self.0)

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.8.5](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.3...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
+## [Upcoming Release](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.3...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
 
 
 ### Features

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 * Add `emath` 0.25 compatibility ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
 * Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
+* Add `new_mask` and `into_inner` ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))
+
 
 ## [0.8.3](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.2...ux2-v0.8.3) (2023-08-30)
 

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+* Add `no_std` compatibility ([191d4f48](https://github.com/JonathanWoollett-Light/ux2/commit/191d4f480c73addc3966be1631955c4a0362647f))
 * Add `emath` 0.25 compatibility ([ae8e529c](https://github.com/JonathanWoollett-Light/ux2/commit/ae8e529c8dc02a0f18be338ca0e2c26fabeec8b4))
 * Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
 * Add `new_mask` and `into_inner` ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 
+* Add `emath` 0.26 compatibility ([fc17d1c0](https://github.com/JonathanWoollett-Light/ux2/commit/fc17d1c0b24065667e2c24740224d178e9cc9d1f))
 * Add `no_std` compatibility ([191d4f48](https://github.com/JonathanWoollett-Light/ux2/commit/191d4f480c73addc3966be1631955c4a0362647f))
 * Add `emath` 0.25 compatibility ([ae8e529c](https://github.com/JonathanWoollett-Light/ux2/commit/ae8e529c8dc02a0f18be338ca0e2c26fabeec8b4))
 * Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 
 * Add `emath` 0.25 compatibility ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
+* Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
 
 ## [0.8.3](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.2...ux2-v0.8.3) (2023-08-30)
 

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.5](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.3...830fb4867373733b9d61ce17a73f388d2d3836ae) (2024-02-02)
+
+
+### Features
+
+* Add `emath` 0.25 compatibility ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
+
 ## [0.8.3](https://github.com/JonathanWoollett-Light/ux2/compare/ux2-v0.8.2...ux2-v0.8.3) (2023-08-30)
 
 

--- a/ux2/CHANGELOG.md
+++ b/ux2/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 
-* Add `emath` 0.25 compatibility ([830fb48](https://github.com/JonathanWoollett-Light/ux2/commit/830fb4867373733b9d61ce17a73f388d2d3836ae))
+* Add `emath` 0.25 compatibility ([ae8e529c](https://github.com/JonathanWoollett-Light/ux2/commit/ae8e529c8dc02a0f18be338ca0e2c26fabeec8b4))
 * Add Default impl ([0816dc83](https://github.com/JonathanWoollett-Light/ux2/commit/0816dc83cb61a54bb99d5967093fc4180af1c4eb))
 * Add `new_mask` and `into_inner` ([88864723](https://github.com/JonathanWoollett-Light/ux2/commit/8886472305f3227586112e3a380b7121be5645aa))
 

--- a/ux2/Cargo.toml
+++ b/ux2/Cargo.toml
@@ -21,7 +21,7 @@ emath = ["dep:emath"]
 
 [dependencies]
 serde = { version = "1.0.160", features = ["derive"], optional = true }
-ux2-macros =  { path = "../ux2-macros", version = "0.9.0" }
+ux2-macros =  { path = "../ux2-macros", version = "0.10.0" }
 emath = {version = "0.25", optional = true}
 
 [dev-dependencies]

--- a/ux2/Cargo.toml
+++ b/ux2/Cargo.toml
@@ -19,11 +19,13 @@ default = ["8", "std"]
 8 = []
 std = []
 emath_0_25 = ["dep:emath_0_25"]
+emath_0_26 = ["dep:emath_0_26"]
 
 [dependencies]
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 ux2-macros =  { path = "../ux2-macros", version = "0.10.0" }
 emath_0_25 = {package = "emath", version = "0.25", optional = true}
+emath_0_26 = {package = "emath", version = "0.26", optional = true}
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ux2/Cargo.toml
+++ b/ux2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ux2"
-version = "0.8.5"
+version = "0.8.6"
 edition = "2021"
 description = "Non-standard integer types like `u7`, `u9`, `u10`, `u63`, `i7`, `i9` etc."
 license = "Apache-2.0"
@@ -17,10 +17,12 @@ default = ["8"]
 32 = ["16"]
 16 = ["8"]
 8 = []
+emath = ["dep:emath"]
 
 [dependencies]
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 ux2-macros =  { path = "../ux2-macros", version = "0.9.0" }
+emath = {version = "0.25", optional = true}
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ux2/Cargo.toml
+++ b/ux2/Cargo.toml
@@ -17,12 +17,12 @@ default = ["8"]
 32 = ["16"]
 16 = ["8"]
 8 = []
-emath = ["dep:emath"]
+emath_0_25 = ["dep:emath_0_25"]
 
 [dependencies]
 serde = { version = "1.0.160", features = ["derive"], optional = true }
 ux2-macros =  { path = "../ux2-macros", version = "0.10.0" }
-emath = {version = "0.25", optional = true}
+emath_0_25 = {package = "emath", version = "0.25", optional = true}
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/ux2/Cargo.toml
+++ b/ux2/Cargo.toml
@@ -11,12 +11,13 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["8"]
+default = ["8", "std"]
 128 = ["64"]
 64 = ["32"]
 32 = ["16"]
 16 = ["8"]
 8 = []
+std = []
 emath_0_25 = ["dep:emath_0_25"]
 
 [dependencies]

--- a/ux2/src/lib.rs
+++ b/ux2/src/lib.rs
@@ -85,7 +85,7 @@ use extra_impls;
 macro_rules! emath_number_impl {
     ($ty:ty, $ident:ident) => {
         impl $ident::Numeric for $ty {
-            const INTEGRAL: bool = false;
+            const INTEGRAL: bool = true;
             const MIN: Self = $ty::MIN;
             const MAX: Self = $ty::MAX;
 

--- a/ux2/src/lib.rs
+++ b/ux2/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
 // https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg
 
 //! # uX2: A better [uX](https://github.com/rust-ux/uX)
@@ -105,21 +106,23 @@ use emath_number_impl;
 /// A mimic of [`std::num::TryFromIntError`] that can be constructed on stable.
 #[derive(Debug, Eq, PartialEq)]
 pub struct TryFromIntError;
-impl std::fmt::Display for TryFromIntError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for TryFromIntError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Failed `TryFrom`.")
     }
 }
+#[cfg(feature = "std")]
 impl std::error::Error for TryFromIntError {}
 
 /// A mimic of [`std::num::ParseIntError`] that can be constructed on stable.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ParseIntError;
-impl std::fmt::Display for ParseIntError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl core::fmt::Display for ParseIntError {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "Failed `TryFrom`.")
     }
 }
+#[cfg(feature = "std")]
 impl std::error::Error for ParseIntError {}
 
 /// https://doc.rust-lang.org/std/primitive.array.html#method.split_array_mut

--- a/ux2/src/lib.rs
+++ b/ux2/src/lib.rs
@@ -78,6 +78,8 @@ macro_rules! extra_impls {
     ($ty:ty) => {
         #[cfg(feature = "emath_0_25")]
         emath_number_impl!($ty, emath_0_25);
+        #[cfg(feature = "emath_0_26")]
+        emath_number_impl!($ty, emath_0_26);
     };
 }
 use extra_impls;

--- a/ux2/src/lib.rs
+++ b/ux2/src/lib.rs
@@ -73,6 +73,35 @@ ux2_macros::generate_types!(16);
 #[cfg(all(feature = "8", not(feature = "16")))]
 ux2_macros::generate_types!(8);
 
+macro_rules! extra_impls {
+    ($ty:ty) => {
+        #[cfg(feature = "emath_0_25")]
+        emath_number_impl!($ty, emath_0_25);
+    };
+}
+use extra_impls;
+
+macro_rules! emath_number_impl {
+    ($ty:ty, $ident:ident) => {
+        impl $ident::Numeric for $ty {
+            const INTEGRAL: bool = false;
+            const MIN: Self = $ty::MIN;
+            const MAX: Self = $ty::MAX;
+
+            #[inline(always)]
+            fn to_f64(self) -> f64 {
+                self.0 as f64
+            }
+
+            #[inline(always)]
+            fn from_f64(num: f64) -> Self {
+                Self::new(num.into_inner())
+            }
+        }
+    }
+}
+use emath_number_impl;
+
 /// A mimic of [`std::num::TryFromIntError`] that can be constructed on stable.
 #[derive(Debug, Eq, PartialEq)]
 pub struct TryFromIntError;


### PR DESCRIPTION
### Summary of the PR

*Please summarize here why the changes in this PR are needed.*

To Construct a `egui::DragValue` the type needs to implement `emath::Number`.
This pr adds a feature to add a `emath::Number` implementation, a `Default` implementation and 2 other convenience functions.

### Requirements

Before submitting your PR, please make sure you addressed the following
requirements:

- [x] All commits in this PR are signed (with `git commit -s`), and the commit
  message has max 60 characters for the summary and max 75 characters for each
  description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [x] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.

Closes: #29 
